### PR TITLE
Fix known mounts displaying as not collected

### DIFF
--- a/AtlasLootClassic/Data/Companion.lua
+++ b/AtlasLootClassic/Data/Companion.lua
@@ -670,7 +670,7 @@ end
 
 function Companion.IsCollectedItem(itemID)
     if COMPANION_DATA[itemID] then
-        return COLLECTED_COMPANIONS[COMPANION_DATA[itemID][2]]
+        return COLLECTED_COMPANIONS[COMPANION_DATA[itemID][1]]
     end
 end
 
@@ -692,13 +692,13 @@ local function UpdateKnownCompanions(typ)
     if typ == "MOUNT" then
         local mountIDs = C_MountJournal.GetMountIDs()
         for i = 1, #mountIDs do
-            local _, _, _, _, _, _, _, _, _, _, isCollected, mountID = C_MountJournal.GetMountInfoByID(mountIDs[i])
-            COLLECTED_COMPANIONS[mountID] = isCollected
+            local _, spellID, _, _, _, _, _, _, _, _, isCollected, mountID = C_MountJournal.GetMountInfoByID(mountIDs[i])
+            COLLECTED_COMPANIONS[spellID] = isCollected
         end
     else
         for i = 1, GetNumCompanions(typ) do
-            local creatureID = GetCompanionInfo(typ, i)
-            COLLECTED_COMPANIONS[creatureID] = true
+            local _, _, creatureSpellID = GetCompanionInfo(typ, i)
+            COLLECTED_COMPANIONS[creatureSpellID] = true
         end
     end
 end


### PR DESCRIPTION
Mounts in COLLECTED_COMPANIONS were saved by mountID instead of creatureID, there for the check for collected was mountID vs creatureID which always returned false. Since there is no easy way from mountID to get creatureID but there is an easy way to get spellID I changed the save and check logic to go by spellID. Changed companions to also be saved via their spellID so there isn't a spellID matching to creatureID (idk if that is even possible)

Changed COLLECTED_COMPANIONS to preserve by summon spell id instead of creature ID

Changed the IsCollectedItem function to check by spell id instead of creature ID
