### PR TITLE
Update data-wrath.lua

### DIFF
--- a/AtlasLootClassic_Crafting/data-cata.lua
+++ b/AtlasLootClassic_Crafting/data-cata.lua
@@ -2059,6 +2059,7 @@ data["CookingCata"] = {
                 { 1, 96133 }, -- Scalding Murglesnout
                 { 2, 88018 }, -- Fish Fry
                 { 3, 88006 }, -- Blackened Surprise
+                { 5, 93741 }, -- Venison Jerky
                 { 16, 88044 }, -- South Island Iced Tea
                 { 17, 88045 }, -- Starfire Espresso
             },

--- a/AtlasLootClassic_Crafting/data-cata.lua
+++ b/AtlasLootClassic_Crafting/data-cata.lua
@@ -2059,7 +2059,6 @@ data["CookingCata"] = {
                 { 1, 96133 }, -- Scalding Murglesnout
                 { 2, 88018 }, -- Fish Fry
                 { 3, 88006 }, -- Blackened Surprise
-                { 5, 93741 }, -- Venison Jerky
                 { 16, 88044 }, -- South Island Iced Tea
                 { 17, 88045 }, -- Starfire Espresso
             },

--- a/AtlasLootClassic_Crafting/data-wrath.lua
+++ b/AtlasLootClassic_Crafting/data-wrath.lua
@@ -513,6 +513,7 @@ data["EnchantingWrath"] = {
             name = AL["Misc"],
             [NORMAL_DIFF] = {
                 { 1, 69412 },	-- Abyssal Shatter
+                { 3, 60619 },   -- Runed Titanium Rod
             }
         },
     }


### PR DESCRIPTION
Update data-wrath.lua
- Added missing Runed Titanium Rod (enchanting)

(Just in case they get included aswell, ignore PR's from Commits on Jun 5, 2024. Accidentally changed something that was actually correct)