### PR TITLE
Fix: Do not add star icons from favourite lists that are not active

### DIFF
--- a/AtlasLootClassic/Addons/Favourites.lua
+++ b/AtlasLootClassic/Addons/Favourites.lua
@@ -844,24 +844,28 @@ function Favourites:CountFavouritesByList(addonName, contentName, boss, dif, inc
         return result
     end
     for l, listData in pairs(self.db.lists) do
-        local listName = listData.__name
-        for i, item in ipairs(items) do
-            if type(item[2]) == "number" then
-                local itemID = item[2]
-                if listData[itemID] and (includeObsolete or not self:IsItemEquippedOrObsolete(itemID, l)) then
-                    result[listName] = (result[listName] or 0) + 1
+        if self:ListIsGlobalActive(l) or self:ListIsProfileActive(l) then
+            local listName = listData.__name
+            for i, item in ipairs(items) do
+                if type(item[2]) == "number" then
+                    local itemID = item[2]
+                    if listData[itemID] and (includeObsolete or not self:IsItemEquippedOrObsolete(itemID, l)) then
+                        result[listName] = (result[listName] or 0) + 1
+                    end
                 end
             end
         end
     end
 
     for l, listData in pairs(self.globalDb.lists) do
-        local listName = listData.__name
-        for i, item in ipairs(items) do
-            if type(item[2]) == "number" then
-                local itemID = item[2]
-                if listData[itemID] and (includeObsolete or not self:IsItemEquippedOrObsolete(itemID, l)) then
-                    result[listName] = (result[listName] or 0) + 1
+        if self:ListIsGlobalActive(l) or self:ListIsProfileActive(l) then
+            local listName = listData.__name
+            for i, item in ipairs(items) do
+                if type(item[2]) == "number" then
+                    local itemID = item[2]
+                    if listData[itemID] and (includeObsolete or not self:IsItemEquippedOrObsolete(itemID, l)) then
+                        result[listName] = (result[listName] or 0) + 1
+                    end
                 end
             end
         end


### PR DESCRIPTION
This PR makes it so that the stars and counters that show up next to the dungeon/difficulty/boss names showing how many items on that group have been added to favourites only takes into account active favourite lists.

Currently all lists contribute to these counts, and if you have different favourites lists in different alts, all of them will show up in the count, making it hard to undertand which dungs have loot that you want for that specific character.

This is what these counts look like
![image](https://github.com/snowflame0/AtlasLootClassic_Cata/assets/60124/b1fa2e40-03cd-44ae-ac53-bc869318ca52)
