### PR TITLE
Scorched Stone is no longer on Ahune's loot table

### DIFF
--- a/AtlasLootClassic_Collections/data-cata.lua
+++ b/AtlasLootClassic_Collections/data-cata.lua
@@ -579,9 +579,8 @@ data["MidsummerFestivalCata"] = {
             { 8, 69767 }, -- The Frost Lord's Battle Shroud
             { 10, 35723 }, -- Shards of Ahune
             { 16, 35498 }, -- Formula: Enchant Weapon - Deathfrost
-            { 18, 34955 }, -- Scorched Stone
-            { 19, 53641 }, -- Ice Chip
-            { 21, 35557 }, -- Huge Snowball
+            { 18, 53641 }, -- Ice Chip
+            { 20, 35557 }, -- Huge Snowball
         }
     }}
 }

--- a/AtlasLootClassic_DungeonsAndRaids/data-tbc.lua
+++ b/AtlasLootClassic_DungeonsAndRaids/data-tbc.lua
@@ -1193,9 +1193,8 @@ data["TheSlavePens"] = {
                 { 8, 69767 }, -- The Frost Lord's Battle Shroud
                 { 10, 35723 }, -- Shards of Ahune
                 { 16, 35498 }, -- Formula: Enchant Weapon - Deathfrost
-                { 18, 34955 }, -- Scorched Stone
-                { 19, 53641 }, -- Ice Chip
-                { 21, 35557 }, -- Huge Snowball
+                { 18, 53641 }, -- Ice Chip
+                { 20, 35557 }, -- Huge Snowball
             },
         }),
         KEYS


### PR DESCRIPTION
Scorched Stone will return as a random reward in Zen'Vorka's Cache — ID 71631 (for 30 Marks of the World Tree) in Molten Front questing area, but for now is no longer on Ahune's loot table.